### PR TITLE
docs: fix failsafe examples

### DIFF
--- a/_includes/video/pb-os-dfp.html
+++ b/_includes/video/pb-os-dfp.html
@@ -48,10 +48,14 @@
         if (pbjs.initAdserverSet) return;
         pbjs.initAdserverSet = true;
         googletag.cmd.push(function () {
-          pbjs.que.push(function () {
-            pbjs.setTargetingForGPTAsync();
+          if (pbjs.libLoaded) {
+            pbjs.que.push(function () {
+              pbjs.setTargetingForGPTAsync();
+              googletag.pubads().refresh();
+            });
+          } else {
             googletag.pubads().refresh();
-          });
+          }
         });
       }
 

--- a/dev-docs/examples/basic-example.md
+++ b/dev-docs/examples/basic-example.md
@@ -73,8 +73,14 @@ function initAdserver() {
   if (pbjs.initAdserverSet) return;
   pbjs.initAdserverSet = true;
   googletag.cmd.push(function() {
-    pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync();
-    googletag.pubads().refresh();
+    if (pbjs.libLoaded) {
+      pbjs.que.push(function() {
+        pbjs.setTargetingForGPTAsync();
+        googletag.pubads().refresh();
+      });
+    } else {
+      googletag.pubads().refresh();
+    }
   });
 }
 

--- a/dev-docs/examples/custom-price-buckets.md
+++ b/dev-docs/examples/custom-price-buckets.md
@@ -97,10 +97,14 @@ function initAdserver() {
     if (pbjs.initAdserverSet) return;
     pbjs.initAdserverSet = true;
     googletag.cmd.push(function() {
-        pbjs.que.push(function() {
-            pbjs.setTargetingForGPTAsync();
+        if (pbjs.libLoaded) {
+            pbjs.que.push(function() {
+                pbjs.setTargetingForGPTAsync();
+                googletag.pubads().refresh();
+            });
+        } else {
             googletag.pubads().refresh();
-        });
+        }
     });
 }
 

--- a/dev-docs/examples/instream-banner-mix.md
+++ b/dev-docs/examples/instream-banner-mix.md
@@ -177,10 +177,14 @@ function initAdserver(bids) {
 
     // Set targeting for each display slot
     googletag.cmd.push(function() {
-        pbjs.que.push(function() {
-            pbjs.setTargetingForGPTAsync(displayAdUnitCodes);
+        if (pbjs.libLoaded) {
+            pbjs.que.push(function() {
+                pbjs.setTargetingForGPTAsync(displayAdUnitCodes);
+                googletag.pubads().refresh();
+            });
+        } else {
             googletag.pubads().refresh();
-        });
+        }
     });
 
     // Build DFP URL with targeting for videoAdUnit

--- a/dev-docs/examples/meta-bid-filtering.md
+++ b/dev-docs/examples/meta-bid-filtering.md
@@ -78,8 +78,14 @@ function initAdserver() {
     if (pbjs.initAdserverSet) return;
     pbjs.initAdserverSet = true;
     googletag.cmd.push(function() {
-        pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync();
-        googletag.pubads().refresh();
+        if (pbjs.libLoaded) {
+            pbjs.que.push(function() {
+                pbjs.setTargetingForGPTAsync();
+                googletag.pubads().refresh();
+            });
+        } else {
+            googletag.pubads().refresh();
+        }
     });
 }
 

--- a/dev-docs/examples/native-ad-example.md
+++ b/dev-docs/examples/native-ad-example.md
@@ -48,10 +48,14 @@ function initAdserver() {
     if (pbjs.initAdserverSet) return;
 
     googletag.cmd.push(function() {
-        pbjs.que.push(function() {
-            pbjs.setTargetingForGPTAsync();
+        if (pbjs.libLoaded) {
+            pbjs.que.push(function() {
+                pbjs.setTargetingForGPTAsync();
+                googletag.pubads().refresh();
+            });
+        } else {
             googletag.pubads().refresh();
-        });
+        }
     });
 
     pbjs.initAdserverSet = true;

--- a/dev-docs/examples/size-mapping.md
+++ b/dev-docs/examples/size-mapping.md
@@ -104,10 +104,14 @@ function sendAdserverRequest() {
     if (pbjs.adserverRequestSent) return;
     pbjs.adserverRequestSent = true;
     googletag.cmd.push(function() {
-        pbjs.que.push(function() {
-            pbjs.setTargetingForGPTAsync();
+        if (pbjs.libLoaded) {
+            pbjs.que.push(function() {
+                pbjs.setTargetingForGPTAsync();
+                googletag.pubads().refresh();
+            });
+        } else {
             googletag.pubads().refresh();
-        });
+        }
     });
 }
 

--- a/dev-docs/examples/sync-tid.md
+++ b/dev-docs/examples/sync-tid.md
@@ -83,9 +83,16 @@ pbjs.que.push(function() {
 function prebidBidsBack() {
     pbjs.initAdserverSet = true;
     googletag.cmd.push(function() {
-        pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync();
-        requestManager.prebid = true;
-        sendBidsToAdServer();
+        if (pbjs.libLoaded) {
+            pbjs.que.push(function() {
+                pbjs.setTargetingForGPTAsync();
+                requestManager.prebid = true;
+                sendBidsToAdServer();
+            });
+        } else {
+            googletag.pubads().refresh();
+            requestManager.adserverRequestSent = true;
+        }
     });
 }
 

--- a/docs-examples/web-example.md
+++ b/docs-examples/web-example.md
@@ -84,8 +84,14 @@ function initAdserver() {
   if (pbjs.initAdserverSet) return;
   pbjs.initAdserverSet = true;
   googletag.cmd.push(function() {
-    pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync();
-    googletag.pubads().refresh();
+    if (pbjs.libLoaded) {
+      pbjs.que.push(function() {
+        pbjs.setTargetingForGPTAsync();
+        googletag.pubads().refresh();
+      });
+    } else {
+      googletag.pubads().refresh();
+    }
   });
 }
 

--- a/examples/video/outstream/pb-ve-outstream-dfp.html
+++ b/examples/video/outstream/pb-ve-outstream-dfp.html
@@ -120,10 +120,14 @@ sidebarType: 4
           if (pbjs.initAdserverSet) return;
           pbjs.initAdserverSet = true;
           googletag.cmd.push(function() {
-              pbjs.que.push(function() {
-                  pbjs.setTargetingForGPTAsync();
+              if (pbjs.libLoaded) {
+                  pbjs.que.push(function() {
+                      pbjs.setTargetingForGPTAsync();
+                      googletag.pubads().refresh();
+                  });
+              } else {
                   googletag.pubads().refresh();
-              });
+              }
           });
       }
 


### PR DESCRIPTION
## Summary
- use `pbjs.libLoaded` to fall back to GPT refresh when Prebid fails to load
- update several integration examples with more resilient adserver logic

## Testing
- `npm test` *(fails: no test specified)*