### PR TITLE
Fix markdown lint issues

### DIFF
--- a/_includes/dev-docs/bidder-meta-data.html
+++ b/_includes/dev-docs/bidder-meta-data.html
@@ -54,14 +54,18 @@
       <td class="pbTd">{% if page.fpd_supported == true %}yes{% elsif page.fpd_supported == false %}no{% else %}check with bidder{% endif %}</td>
     </tr>
     <tr>
-      <th class="pbTh">User IDs</th>
-      <td class="pbTd">{% if page.userIds and page.userIds != '' %}{{page.userIds}}{% else %}none{% endif %}</td>
+      <th class="pbTh">Endpoint Compression</th>
+      <td class="pbTd">{% if page.endpoint_compression == true %}yes{% elsif page.endpoint_compression == false %}no{% else %}check with bidder{% endif %}</td>
       <th class="pbTh">ORTB Blocking Support</th>
       <td class="pbTd">{% if page.ortb_blocking_supported == true %}yes{% elsif page.ortb_blocking_supported == false %}no{% elsif page.ortb_blocking_supported == 'partial' %}partial{% else %}check with bidder{% endif %}</td>
     </tr>
     <tr>
+      <th class="pbTh">User IDs</th>
+      <td class="pbTd">{% if page.userIds and page.userIds != '' %}{{page.userIds}}{% else %}none{% endif %}</td>
       <th class="pbTh">Privacy Sandbox</th>
       <td class="pbTd">{% if page.privacy_sandbox %}{{page.privacy_sandbox}}{% else %}check with bidder{% endif %}</td>
+    </tr>
+    <tr>
       {% if page.pbs == true %}
       <th class="pbTh">Prebid Server App Support</th>
       <td class="pbTd">{% if page.pbs_app_supported == false %}no{% elsif page.pbs_app_supported == true %}yes{% else %}check with bidder{% endif %}</td>
@@ -69,6 +73,8 @@
       <th class="pbTh"></th>
       <td class="pbTd"></td>
       {% endif %}
+      <th class="pbTh"></th>
+      <td class="pbTd"></td>
     </tr>
 
   </table>

--- a/dev-docs/bidder-adaptor.md
+++ b/dev-docs/bidder-adaptor.md
@@ -278,7 +278,7 @@ Prebid.js core now includes support for gzip compression of bidder request paylo
 Prebid will pass compressed payloads if the following criteria are met:
 
 * Participating bidders must implement compression support on their server-side endpoint before making a change in their bid adapter in Prebid.js
-* Once server-side support is present, `request.options.endpointCompression = true` needs to be set for a bidder's outgoing requests within their Prebid.js bid adapter (An example of this can be viewed [here](https://github.com/prebid/Prebid.js/blob/master/modules/pubmaticBidAdapter.js#L730))
+* Once server-side support is present, `request.options.endpointCompression = true` needs to be set for a bidder's outgoing requests within their Prebid.js bid adapter (see the [PubMatic adapter example](https://github.com/prebid/Prebid.js/blob/master/modules/pubmaticBidAdapter.js#L730))
 * The browser must support gzip compression (Prebid core has a built-in utility function to check this)
 
 If the above criteria is met, Prebid.js core will do the following:
@@ -389,6 +389,7 @@ When disabled, `auctionId`/`transactionId` are set to `null`; `ortb2.source.tid`
 There are a number of important values that a publisher expects to be handled in a standard way across all Prebid.js adapters:
 
 {: .table .table-bordered .table-striped }
+
 | Parameter | Description                                   | Example               |
 | ----- | ------------ | ---------- |
 | Ad Server Currency | If your endpoint supports responding in different currencies, read this value. | config.getConfig('currency.adServerCurrency') |
@@ -423,6 +424,7 @@ You shouldn't call your bid endpoint directly. Rather, the end result of your bu
 ServerRequest objects. These objects have this structure:
 
 {: .table .table-bordered .table-striped }
+
 | Attribute | Type             | Description                                                        | Example Value               |
 |-----------+------------------+--------------------------------------------------------------------+-----------------------------|
 | `method`  | String           | Which HTTP method should be used.                                  | `POST`                      |
@@ -504,6 +506,7 @@ particularly useful. Publishers may have analytics or security vendors with the 
 The parameters of the `bidResponse` object are:
 
 {: .table .table-bordered .table-striped }
+
 | Key          | Scope                                       | Description                                                                                                                                   | Example                              |
 |--------------+---------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------|
 | `requestId`  | Required                                    | The bid ID that was sent to `spec.buildRequests` as `bidRequests[].bidId`. Used to tie this bid back to the request.                          | 12345                                |
@@ -760,6 +763,7 @@ spec.aliases can be an array of strings or objects.
 If the alias entry is an object, the following attributes are supported:
 
 {: .table .table-bordered .table-striped }
+
 | Name  | Scope | Description   | Type      |
 |-------|-------|---------------|-----------|
 | `code` | required | shortcode/partner name | `string` |
@@ -962,7 +966,7 @@ Adapter must add following new properties to bid response
 }
 ```
 
-Appnexus Adapter uses above explained approach. You can refer [here](https://github.com/prebid/Prebid.js/blob/master/modules/appnexusBidAdapter.js)
+Appnexus Adapter uses the approach explained above. You can see an example in the [AppNexus adapter](https://github.com/prebid/Prebid.js/blob/master/modules/appnexusBidAdapter.js)
 
 Adapter must return one [IAB accepted subcategories](https://iabtechlab.com/wp-content/uploads/2017/11/IAB_Tech_Lab_Content_Taxonomy_V2_Final_2017-11.xlsx) (links to MS Excel file) if they want to support competitive separation. These IAB sub categories will be converted to Ad server industry/group. If adapter is returning their own proprietary categroy, it is the responsibility of the adapter to convert their categories into [IAB accepted subcategories](https://iabtechlab.com/wp-content/uploads/2017/11/IAB_Tech_Lab_Content_Taxonomy_V2_Final_2017-11.xlsx) (links to MS Excel file).
 
@@ -971,6 +975,7 @@ If the demand partner is going to use Prebid API for this process, their adapter
 **Params**  
 
 {: .table .table-bordered .table-striped }
+
 | Key             | Scope    | Description                                                                                        | Example                    |
 |-----------------|----------|----------------------------------------------------------------------------------------------------|----------------------------|
 | `url`             | Required | The URL to the mapping file.                                                                       | `"//example.com/mapping.json"` |
@@ -1000,6 +1005,7 @@ getIabSubCategory(bidderCode, pCategory)
 **Params**
 
 {: .table .table-bordered .table-striped }
+
 | Key          | Scope    | Description                                   | Example               |
 |--------------|----------|-----------------------------------------------|-----------------------|
 | `bidderCode` | Required | BIDDER_CODE defined in spec.                  | `"sample-biddercode"` |
@@ -1166,7 +1172,7 @@ export const spec = {
          * Determines whether or not the given bid request is valid.
          *
          * @param {BidRequest} bid The bid params to validate.
-         * @return boolean True if this is a valid bid, and false otherwise.
+         * @return {boolean} True if this is a valid bid, and false otherwise.
          */
         isBidRequestValid: function(bid) {
             return !!(bid.params.placementId || (bid.params.member && bid.params.invCode));
@@ -1174,8 +1180,8 @@ export const spec = {
         /**
          * Make a server request from the list of BidRequests.
          *
-         * @param {validBidRequests[]} - an array of bids
-         * @return ServerRequest Info describing the request to the server.
+         * @param {BidRequest[]} validBidRequests - an array of bids
+         * @return {ServerRequest} Info describing the request to the server.
          */
         buildRequests: function(validBidRequests) {
             const payload = {
@@ -1260,7 +1266,7 @@ export const spec = {
 
     /**
      * Register bidder specific code, which will execute if bidder timed out after an auction
-     * @param {data} Containing timeout specific data
+     * @param {Object} data Containing timeout specific data
      */
     onTimeout: function(data) {
         // Bidder specifc code
@@ -1268,7 +1274,7 @@ export const spec = {
 
     /**
      * Register bidder specific code, which will execute if a bid from this bidder won the auction
-     * @param {Bid} The bid that won the auction
+     * @param {Bid} bid The bid that won the auction
      */
     onBidWon: function(bid) {
         // Bidder specific code
@@ -1276,7 +1282,7 @@ export const spec = {
 
     /**
      * Register bidder specific code, which will execute when the adserver targeting has been set for a bid from this bidder
-     * @param {Bid} The bid of which the targeting has been set
+     * @param {Bid} bid The bid of which the targeting has been set
      */
     onSetTargeting: function(bid) {
         // Bidder specific code
@@ -1284,7 +1290,7 @@ export const spec = {
 
     /**
      * Register bidder specific code, which will execute if the bidder responded with an error
-     * @param {error, bidderRequest} An object with the XMLHttpRequest error and the bid request object
+     * @param {Object} params An object with the XMLHttpRequest error and the bid request object
      */
     onBidderError: function({ error, bidderRequest }) {
         // Bidder specific code
@@ -1293,7 +1299,7 @@ export const spec = {
     /**
      * Register bidder specific code, which will execute if the ad
      * has been rendered successfully
-     * @param {bid} bid request object
+     * @param {Bid} bid Bid request object
      */
     onAdRenderSucceeded: function(bid) {
         // Bidder specific code
@@ -1370,6 +1376,7 @@ The Example Bidding adapter requires setup before beginning. Please contact us a
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name          | Scope    | Description           | Example   | Type      |
 |---------------|----------|-----------------------|-----------|-----------|
 | `placement`      | required | Placement id         | `'11111'`    | `string` |

--- a/dev-docs/bidders/deltaprojects.md
+++ b/dev-docs/bidders/deltaprojects.md
@@ -20,6 +20,7 @@ will always bid and log values in the agreed upon currency, utilizing the curren
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name           | Scope    | Description                                                              | Example         | Type     |
 |----------------|----------|--------------------------------------------------------------------------|-----------------|----------|
 | `publisherId`  | required | Publisher ID from Delta Projects. Contact <publishers@deltaprojects.com>   | `'4'`           | `string` |
@@ -32,7 +33,7 @@ will always bid and log values in the agreed upon currency, utilizing the curren
 
 #### Banner
 
-```
+```javascript
 var adUnits = [
   {
     code: 'adunit-code',

--- a/dev-docs/bidders/discovery.md
+++ b/dev-docs/bidders/discovery.md
@@ -15,6 +15,7 @@ The DiscoveryDSP Bidding adapter requires setup before beginning. Please contact
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name          | Scope    | Description           | Example   | Type      |
 |---------------|----------|-----------------------|-----------|-----------|
 | `token`      | required | publisher token        | `'1e100887dd614b7f69fdd1360437'`    | `string` |
@@ -26,7 +27,7 @@ The DiscoveryDSP Bidding adapter requires setup before beginning. Please contact
 
 banner
 
-```
+```javascript
 var adUnits = [
       {
         code: "test-div-1",
@@ -51,7 +52,7 @@ var adUnits = [
 
 native
 
-```
+```javascript
 var adUnits = [
       {
         code: "test-div-2",

--- a/dev-docs/bidders/glomexbidder.md
+++ b/dev-docs/bidders/glomexbidder.md
@@ -1,0 +1,125 @@
+---
+layout: bidder
+title: Glomex Bidder
+description: Prebid Glomex Bidder Adapter
+pbjs: true
+pbs: true
+biddercode: glomexbidder
+gvl_id: 967
+tcfeu_supported: true
+usp_supported: true
+gpp_supported: true
+schain_supported: true
+dchain_supported: true
+floors_supported: true
+userIds: all
+tcfeu_supported: true
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: true
+sidebarType: 1
+fpd_supported: true
+multiformat_supported: will-bid-on-any
+
+---
+
+### Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name          | Scope    | Description                | Example                                   | Type      |
+|---------------|----------|----------------------------|--------------------------------------     |-----------|
+| `tagId`       | optional | tag ID                     | `"testnexx"`                              | `string`  |
+| `placement`   | optional | Placement                  | `"test"`                                  | `string`  |
+
+For the prebid.js you only need to use one parameter: either tagId or placement
+
+### First Party Data
+
+Publishers should use the `ortb2` method of setting [First Party Data](/features/firstPartyData.html).
+The following fields are supported:
+
+* ortb2.site.ext.data.*
+* ortb2.site.content.data[]
+* ortb2.user.ext.data.*
+* ortb2.user.data[]
+
+### Test Parameters
+
+```javascript
+var adUnits = [
+   // Banner adUnit
+   {
+      code: 'banner-div',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [300,600]]
+        }
+      },
+      bids: [{
+         bidder: 'glomexbidder',
+         params: {
+            tagId: 'testeasy'
+         }
+       }]
+   },
+   // Video adUnit
+   {
+        code: 'video1',
+        mediaTypes: {
+            video: {
+                playerSize: [640, 480],
+                context: 'instream'
+            }
+        },
+        bids: [{
+            bidder: 'glomexbidder',
+            params: {
+               tagId: 'testeasy'
+            }
+        }]
+    },
+     // Native adUnit
+   {
+        code: 'native1',
+        mediaTypes:
+            native: {
+                title: {
+                    required: true
+                },
+                image: {
+                    required: true
+                },
+                sponsoredBy: {
+                    required: true
+                }
+            }
+        },
+        bids: [{
+            bidder: 'glomexbidder',
+            params: {
+               tagId: 'testeasy'
+            }
+        }]
+    },
+    // Multiformat Ad
+   {
+        code: 'multi1',
+        mediaTypes: {
+            video: {
+                playerSize: [640, 480],
+                context: 'instream'
+            },
+            banner: {
+              sizes: [[300, 250], [300,600]]
+            }
+        },
+        bids: [{
+            bidder: 'glomexbidder',
+            params: {
+               tagId: 'testeasy',
+               videoTagId: 'testeasy'
+            }
+        }]
+    };
+];
+```

--- a/dev-docs/bidders/logicad.md
+++ b/dev-docs/bidders/logicad.md
@@ -12,6 +12,7 @@ userIds: all
 tcfeu_supported: false
 prebid_member: false
 sidebarType: 1
+schain_supported: true
 ---
 
 

--- a/dev-docs/bidders/movingup.md
+++ b/dev-docs/bidders/movingup.md
@@ -1,0 +1,125 @@
+---
+layout: bidder
+title: Moving Up
+description: Prebid Moving Up Bidder Adapter
+pbjs: true
+pbs: true
+biddercode: movingup
+gvl_id: 1416
+tcfeu_supported: true
+usp_supported: true
+gpp_supported: true
+schain_supported: true
+dchain_supported: true
+floors_supported: true
+userIds: all
+tcfeu_supported: true
+media_types: banner, video, native
+safeframes_ok: true
+deals_supported: true
+sidebarType: 1
+fpd_supported: true
+multiformat_supported: will-bid-on-any
+
+---
+
+### Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name          | Scope    | Description                | Example                                   | Type      |
+|---------------|----------|----------------------------|--------------------------------------     |-----------|
+| `tagId`       | optional | tag ID                     | `"testnexx"`                              | `string`  |
+| `placement`   | optional | Placement                  | `"test"`                                  | `string`  |
+
+For the prebid.js you only need to use one parameter: either tagId or placement
+
+### First Party Data
+
+Publishers should use the `ortb2` method of setting [First Party Data](/features/firstPartyData.html).
+The following fields are supported:
+
+* ortb2.site.ext.data.*
+* ortb2.site.content.data[]
+* ortb2.user.ext.data.*
+* ortb2.user.data[]
+
+### Test Parameters
+
+```javascript
+var adUnits = [
+   // Banner adUnit
+   {
+      code: 'banner-div',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [300,600]]
+        }
+      },
+      bids: [{
+         bidder: 'movingup',
+         params: {
+            tagId: 'testeasy'
+         }
+       }]
+   },
+   // Video adUnit
+   {
+        code: 'video1',
+        mediaTypes: {
+            video: {
+                playerSize: [640, 480],
+                context: 'instream'
+            }
+        },
+        bids: [{
+            bidder: 'movingup',
+            params: {
+               tagId: 'testeasy'
+            }
+        }]
+    },
+     // Native adUnit
+   {
+        code: 'native1',
+        mediaTypes:
+            native: {
+                title: {
+                    required: true
+                },
+                image: {
+                    required: true
+                },
+                sponsoredBy: {
+                    required: true
+                }
+            }
+        },
+        bids: [{
+            bidder: 'movingup',
+            params: {
+               tagId: 'testeasy'
+            }
+        }]
+    },
+    // Multiformat Ad
+   {
+        code: 'multi1',
+        mediaTypes: {
+            video: {
+                playerSize: [640, 480],
+                context: 'instream'
+            },
+            banner: {
+              sizes: [[300, 250], [300,600]]
+            }
+        },
+        bids: [{
+            bidder: 'movingup',
+            params: {
+               tagId: 'testeasy',
+               videoTagId: 'testeasy'
+            }
+        }]
+    };
+];
+```

--- a/dev-docs/bidders/programmaticX.md
+++ b/dev-docs/bidders/programmaticX.md
@@ -1,0 +1,36 @@
+---
+layout: bidder
+title: ProgrammaticX
+description: Prebid ProgrammaticX Bidder Adapter
+biddercode: ProgrammaticX
+gpp_sids: usstate_all
+gvl_id: 1344
+tcfeu_supported: true
+usp_supported: true
+coppa_supported: true
+schain_supported: true
+deals_supported: false
+floors_supported: true
+fpd_supported: false
+ortb_blocking_supported: false
+media_types: banner, video, native
+multiformat_supported: will-bid-on-one
+userIds: all
+pbjs: true
+pbs: false
+pbs_app_supported: true
+safeframes_ok: true
+sidebarType: 1
+---
+
+### Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name          | Scope    | Description  | Example                         | Type       |
+|---------------|----------|--------------|---------------------------------|------------|
+| `placementId` | optional | Placement Id | `'0'`                           | `'string'` |
+| `endpointId`  | optional | Endpoint Id  | `'0'`                           | `'string'` |
+
+### Note
+
+For the prebid server and prebid.js you only need to use one parameter: either placementId or endpointId

--- a/dev-docs/bidders/pubmatic.md
+++ b/dev-docs/bidders/pubmatic.md
@@ -22,6 +22,7 @@ ortb_blocking_supported: true
 gvl_id: 76
 multiformat_supported: will-bid-on-one
 sidebarType: 1
+endpoint_compression: true
 ---
 
 ### Prebid Server Note

--- a/dev-docs/bidders/welect.md
+++ b/dev-docs/bidders/welect.md
@@ -24,15 +24,16 @@ sidebarType: 1
 ---
 
 ### Note
+
 The Welect bidder adapter requires setup and approval from the Welect team. Please reach out to [dev@welect.de](mailto:dev@welect.de) for more information.
 
 ### Bid params
 
 {: .table .table-bordered .table-striped }
+
 | Name | Description | Example | Type |
 |---|---|---|---|
 | `placementId` | an identifier for your placement, provided by Welect | `'exampleID'` | `string` |
-| `domain` | The domain of your placement | `'www.example.com'` | `string` |
 
 ### Example Ad Unit Setup
 
@@ -41,13 +42,12 @@ var adUnits = [
   {
     bidder: 'welect',
     params: {
-      placementId: 'exampleId',
-      domain: 'www.welect.de'
+      placementId: 'exampleId'
     },
-    sizes: [[640, 360]],
     mediaTypes: {
       video: {
-        context: 'instream'
+        context: 'instream',
+        playerSize: [640, 360]
       }
     },
   };

--- a/dev-docs/modules/1plusXRtdProvider.md
+++ b/dev-docs/modules/1plusXRtdProvider.md
@@ -46,7 +46,8 @@ pbjs.setConfig({
             params: {
                 customerId: 'acme',
                 bidders: ['appnexus', 'rubicon'],
-                timeout: TIMEOUT
+                timeout: TIMEOUT,
+                fpidStorageType: 'html5'
             }
         }]
     }
@@ -56,6 +57,7 @@ pbjs.setConfig({
 ## Parameters
 
 {: .table .table-bordered .table-striped }
+
 | Name              | Type          | Description                                                      | Default           |
 | :---------------- | :------------ | :--------------------------------------------------------------- |:----------------- |
 | name              | String        | Real time data module name                                       | Always '1plusX'   |
@@ -64,3 +66,4 @@ pbjs.setConfig({
 | params.customerId | String        | Your 1plusX customer id                                          |                   |
 | params.bidders    | Array<string> | List of bidders for which you would like data to be set          |                   |
 | params.timeout    | Integer       | timeout (ms)                                                     | 1000ms            |
+| params.fpidStorageType | String | Where to read the first party id ('html5' or 'cookie') | 'html5' |

--- a/dev-docs/modules/consentManagementGpp.md
+++ b/dev-docs/modules/consentManagementGpp.md
@@ -54,11 +54,13 @@ Once the CMP is implemented, simply include this module into your build and add 
 Here are the parameters supported in the `consentManagement` object specific for the GPP consent module:
 
 {: .table .table-bordered .table-striped }
+
 | Param | Type | Description | Example |
 | --- | --- | --- | --- |
 | gpp | `Object` | | |
 | gpp.cmpApi | `string` | The CMP interface that is in use. Supported values are **'iab'** or **'static'**. Static allows integrations where IAB-formatted consent strings are provided in a non-standard way. Default is `'iab'`. | `'iab'` |
 | gpp.timeout | `integer` | Length of time (in milliseconds) to allow the CMP to obtain the GPP consent information. Default is `10000`. | `10000` |
+| gpp.actionTimeout | `integer` | Length of time (in milliseconds) to allow the user to take action to consent if they have not already done so. The actionTimer first waits for the CMP to load, then the actionTimeout begins for the specified duration. Default is `undefined`. | `10000` |
 | gpp.consentData | `Object` | An object representing the IAB GPP consent data being passed directly; only used when cmpApi is 'static'. Default is `undefined`. | |
 | gpp.consentData.sectionId | `integer` | Indicates the header section of the GPP consent string, recommended to be `3`. | |
 | gpp.consentData.gppVersion | `string` | The version number parsed from the header of the GPP consent string. | |

--- a/dev-docs/modules/floors.md
+++ b/dev-docs/modules/floors.md
@@ -1295,7 +1295,7 @@ Even if a publisher is using a floors provider, they may wish to provide additio
 
 1. default floor data if dynamic data fails to load on time
 2. global floorMin: allows the publisher to constrain dynamic floors with a global min
-3. impression-level floor min (PBJS 6.24+): allows the publisher to constrain dynamic floors with an adunit-specific value
+3. impression-level floor min (PBJS 6.24+): allows the publisher to constrain dynamic floors with an adunit-specific value. Specify this in `ortb2Imp.ext.prebid.floors.floorMin` (prior to Prebid.js 8 it was `ortb2Imp.ext.prebid.floorMin`).
 
 Here's an example covering the first two scenarios:
 

--- a/dev-docs/modules/geoedgeRtdProvider.md
+++ b/dev-docs/modules/geoedgeRtdProvider.md
@@ -20,7 +20,7 @@ sidebarType : 1
 ## Overview
 
 The Geoedge Realtime module lets publishers block bad ads such as automatic redirects, malware, offensive creatives and landing pages.
-To use this module, you'll need to work with [Geoedge](https://www.geoedge.com/publishers-real-time-protection/) to get an account and cutomer key.
+To use this module, you'll need to work with [Geoedge](https://www.geoedge.com/publishers-real-time-protection/) to get an account and customer key.
 
 {% include dev-docs/loads-external-javascript.md %}
 

--- a/dev-docs/modules/prebidServer.md
+++ b/dev-docs/modules/prebidServer.md
@@ -204,6 +204,48 @@ Here's how it works:
 1. The s2sConfig.bidders array contains 'tripleliftVideo' telling Prebid.js to direct bids for that code to the server
 1. Finally, the extPrebid.aliases line tells Prebid Server to route the 'tripleliftVideo' biddercode to the 'triplelift' server-side adapter.
 
+### Routing for Multiple PBS instances
+
+Bids:
+
+```javascript
+[{
+    bidder: 'foobar',
+    params: {...},
+},
+{
+    bidder: 'foobar',
+    params: {...},
+    pbsHost: 'foobar-2'
+}]
+```
+
+s2sConfig:
+
+```javascript
+[{
+    accountId: 1234,
+    bidders: ['foobar'],
+    enabled: true,
+    endpoint: {
+        noP1Consent : 'https://pbs.auction/openrtb2/auction',
+        p1Consent : 'https://pbs.auction/openrtb2/auction'
+    }
+},
+{
+     accountId: 5678,
+     bidders: ['foobar-2'],
+     syncBidders: ['foobar'],
+     enabled: true,
+     endpoint: {
+        noP1Consent : 'https://pbs.alt.auction/openrtb2/auction',
+        p1Consent : 'https://pbs.alt.auction/openrtb2/auction'
+     }
+}]
+```
+
+The above would distribute `bid[0]` to s2s endpoint `https://pbs.auction/openrtb2/auction`, whereas `bid[1]` will be distributed to `https://pbs.alt.auction/openrtb2/auction`. The syncBidders is used to sync both with the original biddercode to as well as applying bidder specific FPD for pbs calls via bidderconfig.
+
 ### Video via s2sConfig
 
 Supporting video through the Server-to-Server route can be done by providing a couple of extra arguments on the `extPrebid` object. e.g.

--- a/dev-docs/modules/tcfControl.md
+++ b/dev-docs/modules/tcfControl.md
@@ -83,7 +83,7 @@ The following fields related to anonymizing aspects of the auction are supported
 Notes:
 
 * <a id="strictStorageEnforcement"></a> By default, Prebid allows some limited use of storage even when purpose 1 consent was not given: this is limited to non-PII, such as [category translation mappings](/dev-docs/modules/categoryTranslation.html), or temporary test data used to probe the browser's storage features. If `strictStorageEnforcement` is true, Purpose 1 consent will always be enforced for any access to storage.
-* To accomodate Prebid.js modules and adapters that don't have GVL IDs, the vendorExceptions list is based on Prebid.js biddercodes instead of Global Vendor List (GVL) IDs (i.e. "bidderA" instead of "12345").
+* To accommodate Prebid.js modules and adapters that don't have GVL IDs, the vendorExceptions list is based on Prebid.js biddercodes instead of Global Vendor List (GVL) IDs (i.e. "bidderA" instead of "12345").
 * An alternate way of establishing a GVL mapping is to define a 'gvlMapping' object:
 
 ```javascript

--- a/dev-docs/modules/weboramaRtdProvider.md
+++ b/dev-docs/modules/weboramaRtdProvider.md
@@ -150,12 +150,8 @@ On this section we will explain the `params.weboUserDataConf` subconfiguration:
 
 ##### User Consent
 
-The WAM User-Centric configuration will check for user consent if gdpr applies. It will check for consent:
-
-* Vendor ID 284 (Weborama)
-* Purpose IDs: 1, 3, 4, 5 and 6
-
-If the user consent does not match such conditions, this module will not load, means we will not check for any data in local storage and the default profile will be ignored.
+In a user-centric configuration, the WAM module will verify user consent when GDPR is applicable. It specifically checks for consent related to the purposes declared by Weborama in the Global Vendor List (Vendor ID 284). 
+If the required consent is not provided, the module will not activate, and it will neither access local storage nor apply any default user profile.
 
 #### Sfbx LiTE Site-Centric Configuration
 

--- a/dev-docs/plugins/bc/bc-prebid-plugin-render-options.md
+++ b/dev-docs/plugins/bc/bc-prebid-plugin-render-options.md
@@ -321,7 +321,7 @@ String that can be one of the following:
 * `'start'` (for preroll)
 * `'end'` (for postroll)
 * `'hh:mm:ss'` (to specify a midroll at a specific time)
-* `'hh:mm:ss.mmm'` (to specify a midroll at a specfic time, including millseconds)
+* `'hh:mm:ss.mmm'` (to specify a midroll at a specific time, including milliseconds)
 * `'n%'` (to specify a midroll to play after the specified percentage of the content video has played)
 
 **Required?**

--- a/dev-docs/publisher-api-reference/getAllPrebidWinningBids.md
+++ b/dev-docs/publisher-api-reference/getAllPrebidWinningBids.md
@@ -6,6 +6,6 @@ sidebarType: 1
 ---
 
 
-Use this method to get all of the bids that have won their respective auctions but not rendered on the page.  Useful for [troubleshooting your integration]({{site.baseurl}}/dev-docs/prebid-troubleshooting-guide.html).
+Use this method to get all the bids that have been used to generate targeting but have not yet been rendered on the page. It matches winning bids only after targeting has been applied and before the ad is rendered. Useful for [troubleshooting your integration]({{site.baseurl}}/dev-docs/prebid-troubleshooting-guide.html).
 
-* `pbjs.getAllPrebidWinningBids()`: returns an array of bid objects that have won their respective auctions but not rendered on the page.
+* `pbjs.getAllPrebidWinningBids()`: returns an array of bid objects that have been used to generate targeting and have not yet been rendered on the page.

--- a/dev-docs/publisher-api-reference/offEvent.md
+++ b/dev-docs/publisher-api-reference/offEvent.md
@@ -16,7 +16,7 @@ Turns off an event callback defined with [onEvent](/dev-docs/publisher-api-refer
 See the [getEvents](/dev-docs/publisher-api-reference/getEvents.html) function for the full list of eventTypes supported.
 
 Causes PBJS to search through registered event callbacks and remove the
-supplied callbackFunction for the specifc eventType.
+supplied callbackFunction for the specific eventType.
 
 The optional `id` parameter provides more finely-grained event
 callback de-registration.  This makes it possible to de-register callback

--- a/dev-docs/show-prebid-ads-on-amp-pages.md
+++ b/dev-docs/show-prebid-ads-on-amp-pages.md
@@ -292,7 +292,7 @@ If you're using a custom RTC callout rather than one of the pre-defined [vendor 
 
 To review that Prebid on AMP is working properly the following aspects can be looked at:
 
-- Include `#development=1` to the URL to review AMP specifc debug messages in the browser console.
+- Include `#development=1` to the URL to review AMP specific debug messages in the browser console.
 - Look for the Prebid server call in the network panel. You can open this URL in a new tab to view additional debugging information relating to the Prebid Server Stored Bid Request. If working properly, Prebid server will display the targeting JSON for AMP to use.
 - Look for the network call from the Ad Server to ensure that key values are being passed. (For Google Ad Manager these are in the `scp` query string parameter in the network request)
 - Most of the debugging information is omitted from the Prebid Server response unless the `debug=1` parameter is present in the Prebid Server query string. AMP won't add this parameter, so you'll need to grab the Prebid Server URL and manually add it to see the additional information provided.

--- a/examples/video/outstream/pb-ve-outstream-dfp.html
+++ b/examples/video/outstream/pb-ve-outstream-dfp.html
@@ -75,7 +75,7 @@ sidebarType: 4
     <div class="pb-code-hl-wrap">
       <pre class="pb-code-hl">
   <!--put javascript code here-->
-  &lt;script async src="//securepubads.g.doubleclick.net/tag/js/gpt.js"&gt;&lt;/script&gt;
+  &lt;script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"&gt;&lt;/script&gt;
 
   &lt;script&gt;
 

--- a/overview/glossary.md
+++ b/overview/glossary.md
@@ -150,7 +150,7 @@ A URL provided by a bidder requesting to be notified when their bid did not win 
 
 ### Notice URL (nurl)
 
-A URL provided by a bidder as an alternate source of the creative. See the [nurl FAQ entry](/faq/prebid-server-faq.html#how-does-the-notice-url-work-for-prebid-server) for Prebid-specfic details.
+A URL provided by a bidder as an alternate source of the creative. See the [nurl FAQ entry](/faq/prebid-server-faq.html#how-does-the-notice-url-work-for-prebid-server) for Prebid-specific details.
 
 ## Prebid Mobile
 

--- a/prebid-mobile/modules/rendering/android-sdk-integration-gam-native.md
+++ b/prebid-mobile/modules/rendering/android-sdk-integration-gam-native.md
@@ -157,7 +157,7 @@ private fun createNativeAdConfiguration(): NativeAdConfiguration {
 }
 ```
 
-See more NativeAdConfiguration options [here](rendering-native-ad-configuration.html).
+See more NativeAdConfiguration options in the [NativeAdConfiguration guide](rendering-native-ad-configuration.html).
 
 ### Step 4: Load the Ad
 

--- a/prebid-mobile/modules/rendering/ios-sdk-integration-gam-native.md
+++ b/prebid-mobile/modules/rendering/ios-sdk-integration-gam-native.md
@@ -173,7 +173,7 @@ let assets = [
 ]
 ```
 
-See the full description of NativeAdConfiguration options [here](rendering-native-ad-configuration.md).
+See the full description of NativeAdConfiguration options in the [NativeAdConfiguration guide](rendering-native-ad-configuration.md).
 
 ### Step 4: Load the Ad
 

--- a/prebid-mobile/modules/rendering/rendering-deeplinkplus.md
+++ b/prebid-mobile/modules/rendering/rendering-deeplinkplus.md
@@ -19,10 +19,10 @@ Deep Link+ provides a premium user experience while letting advertisers scale re
 
 The new deeplinking format enables buyers to submit:
 
- * primary URL
- * fallback URL
- * primary tracking URL
- * fallback tracking URL
+* primary URL
+* fallback URL
+* primary tracking URL
+* fallback tracking URL
 
 And since Deep Link+ is built into the SDK, there is no need to pop up browser windows and re-directs that deteriorate the user experience.
 
@@ -32,12 +32,11 @@ The schema is supported for both kinds of ads - video and display.
 
 The JSTag integration is not supported yet.
 
-
 ## How it works
 
-
 DSPs should rely on the SDK version in the bid request:
-```
+
+```json
 "displaymanagerver": "4.11.0"
 ```
 
@@ -45,7 +44,7 @@ Starting with version 4.11.0 Android SDK supports deeplink+
 
 To leverage the retargeting campaigns buyers use a specific scheme as click URL in the ad response. That URL describes the deep-linking and failover logic:
 
-```
+```text
 deeplink+://navigate?
     primaryUrl=PRIMARY_DEEPLINK&
     primaryTrackingUrl=PRIMARY_TRACKER&
@@ -59,7 +58,7 @@ The `fallbackUrl` can be any supported URI type (e.g., http, traditional deeplin
 
 For example, below is a Deep Link+ URL whose primary target is the Twitter app, with two (2) primary tracker URLs, a fallback URL directing the user to Twitter’s mobile website if the primary deeplink fails and zero (0) fallback tracker URLs:
 
-```
+```text
 deeplink+://navigate?
     primaryUrl=twitter%3A%2F%2Ftimeline&
     primaryTrackingUrl=http%3A%2F%2Fmopub.com%2Fclicktracking&

--- a/prebid-mobile/pbm-api/android/pbm-util-android.md
+++ b/prebid-mobile/pbm-api/android/pbm-util-android.md
@@ -16,10 +16,9 @@ This page will store any utilities that can used in conjuntion with the Prebid S
 {:toc}
 
 ## Find Prebid Creative Size
-Prebid SDK provides a function `findPrebidCreativeSize` to address a bug in the Google Ad Manager ad server (described [here](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!category-topic/google-admob-ads-sdk/ios/648jzAP2EQY)) where under certain situations ads fail to render. 
+Prebid SDK provides a function `findPrebidCreativeSize` to address a bug in the Google Ad Manager ad server (described in [this Google forum thread](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!category-topic/google-admob-ads-sdk/ios/648jzAP2EQY)) where under certain situations ads fail to render.
 
 It is recommended all Google Ad Manager integrations resize all ads served based on the winning Prebid creative size `findPrebidCreativeSize`. Functionally speaking the Prebid SDK resizes ad slots based on the [onAdLoaded](https://developers.google.com/android/reference/com/google/android/gms/ads/AdListener.html#onAdLoaded()) (when an ad is received) to determine the winning Prehbid ad size to determine how to resize the ad slot.
-
 
 {% include alerts/alert_note.html content="`findPrebidCreativeSize` is supported on Android API versions 19+. Using on earlier versions is safe to use, however the resizing would not function." %}
 
@@ -43,4 +42,3 @@ adView.adListener = object : AdListener() {
     }
 }
 ```
-

--- a/prebid-mobile/pbm-api/ios/code-integration-ios.md
+++ b/prebid-mobile/pbm-api/ios/code-integration-ios.md
@@ -221,7 +221,7 @@ As part of Apple's evolving privacy policies, SDKs that access user data in a wa
 
 Currently, the Prebid Mobile SDK is not classified as one of these SDKs. But future changes from Apple or internal app review policies may prompt publishers to proactively register the Prebid Server (PBS) endpoint in the privacy manifest. To support this, the Prebid SDK is designed to accommodate both tracking and non-tracking PBS domains. Here are the Prebid recommendations:
 
-- Include the relevant `NSPrivacyCollectedDataTypes` and define your primary Prebid Server domain in the `NSPrivacyTrackingDomains` array in your the `PrivacyInfo.xcprivacy` file to cover a potential "worst case" scenario. Read more about the `PrivacyInfo.xcprivacy` data [here](https://docs.prebid.org/faq/prebid-mobile-faq.html#privacysecurity).
+- Include the relevant `NSPrivacyCollectedDataTypes` and define your primary Prebid Server domain in the `NSPrivacyTrackingDomains` array in your the `PrivacyInfo.xcprivacy` file to cover a potential "worst case" scenario. Read more about the `PrivacyInfo.xcprivacy` data in the [Prebid Mobile FAQ](https://docs.prebid.org/faq/prebid-mobile-faq.html#privacysecurity).
 - You may choose to provide a secondary, privacy-mode PBS URL to the SDK. This secondary domain can be used when tracking is disallowed. Get this additional hostname from your Prebid Server host provider. Every initialization method contains optional parameter to define this privacy-safe PBS domain. Since these requests will have the `limit ad tracking` flag defined, Prebid Server will anonymize the requests.
 
 You’re not required to use a secondary PBS domain -- you can simply allow iOS to block PBS requests when the user opts out of tracking.

--- a/prebid-mobile/pbm-api/ios/pbm-util-ios.md
+++ b/prebid-mobile/pbm-api/ios/pbm-util-ios.md
@@ -17,7 +17,7 @@ This page will store any utilities that can used in conjuntion with the Prebid S
 
 ## Find Prebid Creative Size
 
-Prebid SDK provides a function `findPrebidCreativeSize` to address a bug in the Google Ad Manager ad server (described [here](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!category-topic/google-admob-ads-sdk/ios/648jzAP2EQY)) where under certain situations ads fail to render. 
+Prebid SDK provides a function `findPrebidCreativeSize` to address a bug in the Google Ad Manager ad server (described in [this Google forum thread](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!category-topic/google-admob-ads-sdk/ios/648jzAP2EQY)) where under certain situations ads fail to render.
 
 It is recommended all Google Ad Manager integrations resize all ads served based on the winning Prebid creative size `findPrebidCreativeSize`. Functionally speaking the Prebid SDK resizes ad slots based on the [adViewDidReceiveAd event](https://developers.google.com/admob/ios/banner) (when an ad is received) to determine the winning Prehbid ad size to determine how to resize the ad slot.
 

--- a/prebid-mobile/prebid-mobile-privacy-regulation.md
+++ b/prebid-mobile/prebid-mobile-privacy-regulation.md
@@ -57,6 +57,7 @@ To ensure proper monetization and relevant targeting, the SDK should be enabled 
 - Describing the actions taken for the different purposeConsents values in combination with consentRequired values.
 
 {: .table .table-bordered .table-striped }
+
 |                     | deviceAccessConsent= true    | deviceAccessConsent= false     | deviceAccessConsent= undefined        |
 |---------------------|------------------------------|--------------------------------|---------------------------------------|
 |consentRequired=false<br>(gdprApplies = false)|The SDK will read and pass IDFA/AAID info to server. |The SDK will **not** read and pass IDFA/AAID info to server. | The SDK will read and pass IDFA/AAID info to server.|

--- a/prebid-mobile/prebid-mobile.md
+++ b/prebid-mobile/prebid-mobile.md
@@ -178,7 +178,7 @@ Follow these steps to integrate the rendering API:
 Currently Prebid Mobile SDK doesn't offer direct analytics capabilities. While we build out analytics in Prebid Server to support the SDK, some options are:
 
 - Generate analytics from the ad server, as key metrics are available there if the line items are broken out by bidder.
-- Integrate an analytics package directly into the app. You may have one already that can accomodate header bidding metrics.
+- Integrate an analytics package directly into the app. You may have one already that can accommodate header bidding metrics.
 - Utilize a server-side [analytics module for Prebid Server](/prebid-server/developers/pbs-build-an-analytics-adapter.html).
 
 ## Further Reading

--- a/prebid-server/pbs-modules/51degrees-device-detection.md
+++ b/prebid-server/pbs-modules/51degrees-device-detection.md
@@ -7,7 +7,7 @@ sidebarType : 5
 ---
 
 {: .alert.alert-warning :}
-51Degrees module operates using a data file. You can get started with a free Lite data file that can be downloaded [here](https://github.com/51Degrees/device-detection-data/blob/main/51Degrees-LiteV4.1.hash). The Lite file is updated monthly and detects limited device information. To access the daily updated full data file with comprehensive device information please [contact 51Degrees](https://51degrees.com/contact-us).
+51Degrees module operates using a data file. You can get started with a free Lite data file that can be downloaded from the [51Degrees data repository](https://github.com/51Degrees/device-detection-data/blob/main/51Degrees-LiteV4.1.hash). The Lite file is updated monthly and detects limited device information. To access the daily updated full data file with comprehensive device information please [contact 51Degrees](https://51degrees.com/contact-us).
 
 # 51Degrees Device Detection Module
 {:.no_toc}
@@ -43,7 +43,7 @@ pbjs.setConfig({
 
 ### Data File Updates
 
-The module operates **fully autonomously and does not make any requests to any cloud services in real time to do device detection**. This is an [on-premise data](https://51degrees.com/developers/deployment-options/on-premise-data) deployment in 51Degrees terminology. The module operates using a local data file that is loaded into memory fully or partially during operation. The data file is occasionally updated to accomodate new devices, so it is recommended to enable automatic data updates in the module configuration. Alternatively `watch_file_system` option can be used and the file may be downloaded and replaced on disk manually. See the configuration options below. 
+The module operates **fully autonomously and does not make any requests to any cloud services in real time to do device detection**. This is an [on-premise data](https://51degrees.com/developers/deployment-options/on-premise-data) deployment in 51Degrees terminology. The module operates using a local data file that is loaded into memory fully or partially during operation. The data file is occasionally updated to accommodate new devices, so it is recommended to enable automatic data updates in the module configuration. Alternatively `watch_file_system` option can be used and the file may be downloaded and replaced on disk manually. See the configuration options below.
 
 ## Setup
 
@@ -251,10 +251,11 @@ The parameter names are specified with full path using dot-notation.  F.e. `sect
 ```
 
 {: .table .table-bordered .table-striped }
+
 | PBS-Java Name | PBS-Go Name | Required| Type | Default  value | Description |
 |:-------|:-------|:------|:------|:------|:---------------------------------------|
 | `account-filter` .`allow-list` |  `account_filter` .`allow_list`  |  No | list of strings | [] (empty list) | A list of account IDs that are allowed to use this module - only relevant if enabled globally for the host. If empty, all accounts are allowed. Full-string match is performed (whitespaces and capitalization matter). |
-| `data-file` .`path`    |  `data_file` .`path`  |  **Yes** | string | null |The full path to the device detection data file. Sample file can be downloaded from [data repo on GitHub](https://github.com/51Degrees/device-detection-data/blob/main/51Degrees-LiteV4.1.hash), or get an Enterprise data file [here](https://51degrees.com/pricing). |
+| `data-file` .`path`    |  `data_file` .`path`  |  **Yes** | string | null |The full path to the device detection data file. Sample file can be downloaded from the [51Degrees data repository](https://github.com/51Degrees/device-detection-data/blob/main/51Degrees-LiteV4.1.hash), or get an Enterprise data file from the [51Degrees pricing page](https://51degrees.com/pricing). |
 | `data-file` .`make-temp-copy` | `data_file` .`make_temp_copy` | No | boolean | true | If true, the engine will create a temporary copy of the data file rather than using the data file directly. |
 | `data-file` .`update` .`auto` | `data_file` .`update` .`auto` | No | boolean | true | If enabled, the engine will periodically (at predefined time intervals - see `polling-interval` parameter) check if new data file is available. When the new data file is available engine downloads it and switches to it for device detection. If custom `url` is not specified `license_key` param is required. |
 | `data-file` .`update` .`on-startup` | `data_file` .`update` .`on_startup` | No | boolean | true | If enabled, engine will check for the updated data file right away without waiting for the defined time interval. |

--- a/prebid-server/pbs-modules/ortb2-blocking.md
+++ b/prebid-server/pbs-modules/ortb2-blocking.md
@@ -687,7 +687,7 @@ This attribute is related to the 'btype' of the request.
 
 See Table 5.2 in the [OpenRTB 2.5 spec](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf) for the possible values.
 
-**Note:** no enforcement is possible because the creative type is not explictly
+**Note:** no enforcement is possible because the creative type is not explicitly
 part of the response and Prebid Server does not currently contain logic to
 parse creatives to derive the type.
 

--- a/prebid/native-implementation-legacy.md
+++ b/prebid/native-implementation-legacy.md
@@ -52,6 +52,7 @@ This table summarizes how the 3 approaches work:
 **Table 1: Native Implementation Approaches**
 
 {: .table .table-bordered .table-striped }
+
 | Component | AdServer-Defined Creative Scenario | AdUnit-Defined Creative Scenario | Custom Renderer Scenario |
 | --- | --- |--- | --- |
 | Prebid.js | mediaTypes. native.sendTargetingKeys: false | sendTargetingKeys:false and mediaTypes.native.adTemplate contains ##macros## | sendTargetingKeys:false and mediaTypes.native.rendererUrl |
@@ -67,6 +68,7 @@ The Prebid.js AdUnit needs to defines a native mediatype object to tell bidders 
 **Table 2: Prebid.js AdUnit Native MediaType Options**
 
 {: .table .table-bordered .table-striped }
+
 | Attribute | Scope | Description | Example | Type |
 | --- | --- | --- | --- | --- |
 | sendTargetingKeys | optional | Defines whether or not to send the hb_native_ASSET targeting keys to the ad server. Defaults to `true` for now, though we recommend setting this to `false` and utilizing one of the ways to define a native template. | `false` | boolean |

--- a/prebid/prebidjsReleases.md
+++ b/prebid/prebidjsReleases.md
@@ -14,6 +14,7 @@ the [GitHub releases page](https://github.com/prebid/Prebid.js/releases) can be 
 The table below is a summary of feature changes and important bug fixes in core of Prebid.js. Almost [all releases](https://github.com/prebid/Prebid.js/releases) have new bid adapters or updates to existing adapters -- what's listed here is limited to core functionality. Releases with only minor core changes may not be shown here, and releases with multiple important changes may be shown more than once.
 
 {: .table .table-bordered .table-striped }
+
 | Release | Feature |
 | --- | --- |
 | 8.0 | Module removals, reliabe (opt-in) transaction identifier, size mapping module & acitivy control. See the [PBJS 8 release notes](/dev-docs/pb8-notes.html) |


### PR DESCRIPTION
## Summary
- fix markdown lint issues in documentation tables

## Testing
- `markdownlint --config .markdownlint.json prebid/prebidjsReleases.md prebid/native-implementation-legacy.md`
- `bundle exec jekyll build` *(fails: rbenv version `2.7.6` is not installed)*