### PR TITLE
Remove JSZip from download page

### DIFF
--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -109,17 +109,8 @@
             var jsBlob = new Blob([data], { type: "text/javascript" });
             var configData = JSON.stringify({ version: form_data.version, modules: form_data.modules }, null, 2);
 
-            if (window.JSZip) {
-                var zip = new JSZip();
-                zip.file(filename, jsBlob);
-                zip.file("prebid-config.json", configData);
-                zip.generateAsync({ type: "blob" }).then(function (zipBlob) {
-                    triggerDownload(zipBlob, "prebid-" + form_data.version + ".zip");
-                });
-            } else {
-                triggerDownload(jsBlob, filename);
-                triggerDownload(new Blob([configData], { type: "application/json" }), "prebid-config.json");
-            }
+            triggerDownload(jsBlob, filename);
+            triggerDownload(new Blob([configData], { type: "application/json" }), "prebid-config.json");
 
             if (form_data["removedModules"].length > 0) {
                 alert(

--- a/download.md
+++ b/download.md
@@ -33,7 +33,6 @@ a.tip:hover span {
 </style>
 
 <script src="https://cdn.firebase.com/js/client/2.4.2/firebase.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.min.js"></script>
 <script src="/assets/js/download.js"></script>
 
 <style>


### PR DESCRIPTION
## Summary
- remove JSZip dependency from `download.js`
- strip JSZip script tag from `download.md`

## Testing
- `npx markdownlint --config .markdownlint.json download.md`
- `bundle exec jekyll build` *(fails: rbenv: version `2.7.6` is not installed)*