### PR TITLE
Add parameter docs to modules

### DIFF
--- a/dev-docs/modules/arcspanRtdProvider.md
+++ b/dev-docs/modules/arcspanRtdProvider.md
@@ -56,5 +56,13 @@ pbjs.setConfig({
 })
 ```
 
+### Parameters
+
+{: .table .table-bordered .table-striped }
+
+| Name | Type | Description | Required | Default |
+| :--- | :--- | :--- | :--- | :--- |
+| `silo` | Integer | ArcSpan provided silo identifier used to load the contextual script | yes | n/a |
+
 {: .alert.alert-info :}
 For best results, we recommend that you also deploy ArcSpan's JavaScript tag in your tag management solution, as instructed in the implementation overview you received from your ArcSpan representative. This will ensure that more of your auctions contain ArcSpan's contextual signals. Please reach out to your ArcSpan representative if you have any questions.

--- a/dev-docs/modules/categoryTranslation.md
+++ b/dev-docs/modules/categoryTranslation.md
@@ -38,6 +38,14 @@ pbjs.setConfig({
 });
 ```
 
+### Parameters
+
+{: .table .table-bordered .table-striped }
+
+| Name | Type | Description | Required | Default |
+| :--- | :--- | :--- | :--- | :--- |
+| `translationFile` | String | URL of a custom brand category translation map | no | Prebid default map |
+
 This file will be stored locally to expedite the conversion process. If a publisher opts to not provide a conversion mapping file Prebid will use its default conversion mapping file.
 
 Publishers should ensure that the JSON returned from their custom file is valid for Prebid by adhering to the following structure:

--- a/dev-docs/modules/confiantRtdProvider.md
+++ b/dev-docs/modules/confiantRtdProvider.md
@@ -53,3 +53,14 @@ pbjs.setConfig({
     }
 });
 ```
+
+## Parameters
+
+{: .table .table-bordered .table-striped }
+
+| Name | Type | Description | Required | Default |
+| :--- | :--- | :--- | :--- | :--- |
+| `propertyId` | String | Identifier provided by Confiant | yes | n/a |
+| `prebidExcludeBidders` | String | Comma separated bidder codes to exclude from Confiant scanning | no | empty |
+| `prebidNameSpace` | String | Custom namespace for the integration | no | empty |
+| `shouldEmitBillableEvent` | Boolean | Emit a billable event when a Confiant scan occurs | no | `false` |

--- a/dev-docs/modules/dsaControl.md
+++ b/dev-docs/modules/dsaControl.md
@@ -30,7 +30,7 @@ pbjs.setConfig({
       regs: {
           ext: {
               dsa: {
-                  dsarequired: 2,  
+                  dsarequired: 2,
                   pubrender: 0
                   // ...
               }
@@ -39,6 +39,15 @@ pbjs.setConfig({
   }
 })
 ```
+
+### Parameters
+
+{: .table .table-bordered .table-striped }
+
+| Name | Type | Description | Required | Default |
+| :--- | :--- | :--- | :--- | :--- |
+| `dsarequired` | Integer | Indicates if DSA transparency information must be included (`0` = not required, `2` = required but advertiser may render, `3` = required and advertiser must render) | yes | n/a |
+| `pubrender` | Integer | Signals publisher rendering capabilities (`0` = cannot render, `2` = will render) | yes | n/a |
 
 This module will then enforce that:
 

--- a/dev-docs/modules/freewheel.md
+++ b/dev-docs/modules/freewheel.md
@@ -59,6 +59,15 @@ pbjs.adServers.freewheel.getTargeting({
 }
 ```
 
+### Parameters
+
+{: .table .table-bordered .table-striped }
+
+| Name | Type | Description | Required | Default |
+| :--- | :--- | :--- | :--- | :--- |
+| `codes` | Array<string> | AdUnit codes to retrieve targeting for | yes | n/a |
+| `callback` | Function | Function invoked with error and targeting map | yes | n/a |
+
 The values returned by `getTargeting` are concatenation of CPM, industy code, and video duration. FreeWheel SDK will send those values to FreeWheel Ad Server within the following query:
 
 ```text

--- a/dev-docs/modules/mediafilterRtdProvider.md
+++ b/dev-docs/modules/mediafilterRtdProvider.md
@@ -47,3 +47,11 @@ pbjs.setConfig({
     }
 });
 ```
+
+### Parameters
+
+{: .table .table-bordered .table-striped }
+
+| Name | Type | Description | Required | Default |
+| :--- | :--- | :--- | :--- | :--- |
+| `configurationHash` | String | Hash provided by The Media Trust to load the protection script | yes | n/a |


### PR DESCRIPTION
## Summary
- document `silo` in ArcSpan RTD module
- document Confiant RTD module parameters
- document Mediafilter RTD module `configurationHash`
- document translationFile for categoryTranslation
- document dsaControl module parameters
- document Freewheel getTargeting parameters

## Testing
- `markdownlint --config .markdownlint.json dev-docs/modules/arcspanRtdProvider.md dev-docs/modules/confiantRtdProvider.md dev-docs/modules/mediafilterRtdProvider.md dev-docs/modules/categoryTranslation.md dev-docs/modules/dsaControl.md dev-docs/modules/freewheel.md`
- `bundle exec jekyll build` *(fails: rbenv: version `2.7.6' is not installed)*