### PR TITLE
codex: download page JS improvements

### DIFF
--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -64,6 +64,15 @@
         }
     }
 
+    function triggerDownload(blob, filename) {
+        var link = document.createElement("a");
+        link.href = window.URL.createObjectURL(blob);
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+    }
+
     function submit_download() {
         $('#download-button').html('<i class="glyphicon glyphicon-send"></i> Sending Request...').addClass('disabled');
 
@@ -90,13 +99,11 @@
                     filename = matches[1].replace(/['"]/g, "");
             }
             // The actual download
-            var blob = new Blob([data], { type: "text/javascript" });
-            var link = document.createElement("a");
-            link.href = window.URL.createObjectURL(blob);
-            link.download = filename;
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
+            var jsBlob = new Blob([data], { type: "text/javascript" });
+            var configData = JSON.stringify({ version: form_data.version, modules: form_data.modules }, null, 2);
+
+            triggerDownload(jsBlob, filename);
+            triggerDownload(new Blob([configData], { type: "application/json" }), "prebid-config.json");
             if (window.pako) {
                 try {
                     var gz = pako.gzip(data);


### PR DESCRIPTION
## Summary
- add helper `triggerDownload` for JS download
- generate config JSON download
- show gzipped package size using pako

## Testing
- `bundle exec jekyll build` *(fails: rbenv version '2.7.6' is not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683f6378e0b0832bb62a31495a9fd4b8