### PR TITLE
Document missing module parameters

### DIFF
--- a/dev-docs/modules/intersectionRtdProvider.md
+++ b/dev-docs/modules/intersectionRtdProvider.md
@@ -2,6 +2,7 @@
 layout: page_v2
 title: Intersection Module
 display_name: Intersection
+
 description: Real Time Intersection
 page_type: module
 module_type: rtd
@@ -26,6 +27,7 @@ Implementation works like this:
 1. Build the Intersection module into the Prebid.js package with:
 
     ```bash
+
     gulp build --modules=intersectionRtdProvider&...
     ```
 
@@ -36,6 +38,7 @@ Implementation works like this:
 This module is configured as part of the `realTimeData.dataProviders` object:
 
 ```javascript
+
 pbjs.setConfig({
     "realTimeData": {
         auctionDelay: 100,
@@ -45,7 +48,10 @@ pbjs.setConfig({
         }]
     }
 });
+
 ```
+
+The optional `waitForIt` flag instructs the module to delay the auction until intersection data is collected for all ad units or the `auctionDelay` timeout is reached. It defaults to `false`.
 
 ## Output
 
@@ -53,6 +59,7 @@ For each bidder, the module adds intersection in a JSON format.
 Example:
 
 ```javascript
+
 {
   "intersection":{
     'boundingClientRect': {

--- a/dev-docs/modules/userid-submodules/unified.md
+++ b/dev-docs/modules/userid-submodules/unified.md
@@ -38,6 +38,8 @@ The Unified ID privacy is covered under the [TradeDesk Services Privacy Policy](
 | params.url | Required for UnifiedId if not using TradeDesk | String | If specified for UnifiedId, overrides the default Trade Desk URL. | "<https://unifiedid.org/somepath?args>" |
 | value | Optional | Object | Used only if the page has a separate mechanism for storing the Unified ID. The value is an object containing the values to be sent to the adapters. In this scenario, no URL is called and nothing is added to local storage | `{"tdid": "D6885E90-2A7A-4E0F-87CB-7734ED1B99A3"}` |
 
+Either `params.partner` or `params.url` must be provided.
+
 ## Unified ID Examples
 
 1. Publisher has a partner ID with The Trade Desk, and is using the default endpoint for Unified ID.

--- a/dev-docs/modules/userid-submodules/yandex.md
+++ b/dev-docs/modules/userid-submodules/yandex.md
@@ -39,3 +39,5 @@ pbjs.setConfig({
     },
 });
 ```
+
+**Storage Requirements**: Yandex ID requires the storage object to specify cookie `type`, name `_ym_uid`, and an expiration of at least 30 days.

--- a/identity/sharedid.md
+++ b/identity/sharedid.md
@@ -21,6 +21,7 @@ SharedId is a convenient Prebid-owned first party identifier within the [Prebid 
 There are multiple ways to integrate SharedId on your site. See the table below for a breakout of options, and the rest of this document for detailed integration instructions.
 
 {: .table .table-bordered .table-striped }
+
 | Implementation | Description | Cookie Lifetime | Safari Cookie Lifetime | Technical Difficulty | Revenue Benefit |
 | --- | --- | --- | --- | --- | --- |
 | 3rd Party Cookie Only | No first party cookie solution. | Some Blocked | Blocked | None | Low |
@@ -149,7 +150,7 @@ removed in Prebid.js 5.0.
 
 ### Configuration
 
-You can find available configuration options for the SharedID module [here](https://docs.prebid.org/dev-docs/modules/userid-submodules/sharedid.html)
+You can find available configuration options for the SharedID module [in the SharedId user ID submodule documentation](https://docs.prebid.org/dev-docs/modules/userid-submodules/sharedid.html)
 
 ### Privacy Discussion
 
@@ -211,6 +212,7 @@ If custom configurations are needed, define the pubcid_options object before inc
 Below are the available configuration options for the PubCID script.
 
 {: .table .table-bordered .table-striped }
+
 | Parameter Name | Type | Description | | Example |
 | --- | --- | --- | --- | --- |
 | create | boolean | If true, then an id is created automatically by the script if it's missing. Default is true. If your server has a component that generates the id instead, then this should be set to false | | `true` |
@@ -218,6 +220,7 @@ Below are the available configuration options for the PubCID script.
 | extend | boolean | If true, the the expiration time is automatically extended whenever the script is executed even if the id exists already. Default is true. If false, then the id expires from the time it was initially created. | For publisher server support only. If true, the publisher's server will create the (pubcid) cookie. Default is true. | `true` |
 | pixelUrl | string (optional) | For publisher server support only. Where to call out to for a server cookie. | | `/wp-json/pubcid/v1/extend/` |
 | type | string | Type of storage. It's possible to specify one of the following: 'html5', 'cookie'. Default is 'html5' priority, aka local storage, and fall back to cookie if local storage is unavailable. | If true, the expiration time of the stored IDs will be refreshed during each page load. Default is false. | `cookie` |
+| inserter | string (optional) | Adds this value into the EID object `inserter` field. | | `myPartner` |
 
 #### Example Configurations
 


### PR DESCRIPTION
## Summary
- document `waitForIt` flag for the Intersection RTD module
- clarify storage requirements for the Yandex user ID module
- note partner/url requirement for Unified ID
- add `inserter` configuration option to SharedId docs
- run markdownlint

## Testing
- `npx markdownlint --config .markdownlint.json identity/sharedid.md dev-docs/modules/intersectionRtdProvider.md dev-docs/modules/userid-submodules/yandex.md dev-docs/modules/userid-submodules/unified.md`
- `bundle exec jekyll build` *(fails: Liquid Exception)*

------
https://chatgpt.com/codex/tasks/task_b_68406cc56310832b9f1195b83d31a20c