### PR TITLE
docs: document additional bidder params

### DIFF
--- a/dev-docs/bidders/33across.md
+++ b/dev-docs/bidders/33across.md
@@ -52,6 +52,8 @@ var adUnits = [
     params: {
         siteId: 'examplePub123',    // required 
         productId: 'siab|inview'    // required
+        // optional: uncomment to enable test requests
+        // test: 1
     }
   }]
 }

--- a/dev-docs/bidders/adf.md
+++ b/dev-docs/bidders/adf.md
@@ -23,13 +23,15 @@ sidebarType: 1
 ### Bid params
 
 {: .table .table-bordered .table-striped }
+
 | Name        | Scope                      | Description          | Example            | Type      |
 |-------------|----------------------------|----------------------|--------------------|-----------|
 | `mid`       | required, if `inv` and `nmane` not set | Placement ID | `12345`        | `integer` |
 | `inv`       | required, if `mid` not set | Inventory source ID  | `1234`             | `integer` |
 | `mname`     | required, if `mid` not set | Placement name       | `"Leaderboard"`    | `string`  |
 | `adxDomain` | optional, Prebid.js only   | The Adform domain    | `"adx.adform.net"` | `string`  |
-| `priceType` | optional                   | Price type           | `"gross"`          | `string`  |
+| `priceType` (alias `pt`) | optional | Price type | `"gross"` | `string` |
+| `test` | optional | Set to `1` to enable test mode | `1` | `integer` |
 
 Note: Bid placement should be defined using the `mid` parameter or `inv` and `mname` parameters (dynamic master tag) but not both.
 

--- a/dev-docs/bidders/eskimi.md
+++ b/dev-docs/bidders/eskimi.md
@@ -24,12 +24,17 @@ sidebarType: 1
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name              | Scope    | Description                     | Example                | Type      |
 |-------------------|----------|---------------------------------|------------------------|-----------|
 | `placementId`     | required | The placement ID from Eskimi.   | `612`                  | `integer` |
 | `bcat`            | optional | ORTB blocked categories         | `['IAB-1-1']`          | `string[]`|
 | `badv`            | optional | ORTB blocked advertiser domains | `['example.com']`      | `string[]`|
 | `bapp`            | optional | ORTB blocked applications       | `['com.example.game']` | `string[]`|
+| `bidFloor`        | optional | Minimum CPM                   | `0.3`                | `number` |
+| `bidFloorCur`     | optional | Currency of bid floor         | `'USD'`              | `string` |
+| `coppa`           | optional | Set to `true` to enable COPPA  | `true`               | `boolean` |
+| `test`            | optional | Set to `1` to enable test mode | `1`                  | `integer` |
 
 Additionally `battr` ORTB blocking param may be set on `BANNER` and `VIDEO` media types to specify blocked creative
 attributes.

--- a/dev-docs/bidders/madsense.md
+++ b/dev-docs/bidders/madsense.md
@@ -26,6 +26,9 @@ The MadSense Header Bidding adapter needs approval from the MadSense team. For m
 ### Bid Params
 
 {: .table .table-bordered .table-striped }
+
 | Name | Scope    | Description        | Example     | Type      |
 |------|----------|--------------------|-------------|-----------|
 | `company_id` | required | Company ID | `'1234567'` | `string`  |
+| `bidfloor`   | optional | Bid floor price | `0.5` | `number` |
+| `currency`   | optional | Bid floor currency | `'USD'` | `string` |


### PR DESCRIPTION
## Summary
- document `test` in 33across banner example
- add `bidfloor` and `currency` to madsense
- document bid floor, `coppa` and `test` params for eskimi
- note `pt` alias and `test` for adf

## Testing
- `npx markdownlint --config .markdownlint.json dev-docs/bidders/33across.md dev-docs/bidders/adf.md dev-docs/bidders/eskimi.md dev-docs/bidders/madsense.md`
- `bundle exec jekyll build` *(fails: rbenv version `2.7.6` is not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68406ca56168832bbd7bc453fa115d4a