### PR TITLE
docs: fix markdownlint issues

### DIFF
--- a/_includes/dev-docs/native-assets.md
+++ b/_includes/dev-docs/native-assets.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 {: .table .table-bordered .table-striped }
 | Asset Code       | Description                                                                          | Macro |
 |---------------+--------------------------------------------------------------------------------------|-----------------------|
@@ -9,8 +10,8 @@
 | `image`       | A picture that is associated with the brand, or grabs the user's attention.          | `##hb_native_image##`     |
 | `clickUrl`    | Where the user will end up if they click the ad.                                     | `##hb_native_linkurl##`   |
 | `displayUrl`  | Text that can be displayed instead of the raw click URL. e.g, "Example.com/Specials" | `##hb_native_displayUrl##`|
-| `privacyLink` | Link to the Privacy Policy of the Buyer, e.g. http://example.com/privacy             | `##hb_native_privacy##`   |
-| `privacyIcon` | Icon to display for the privacy link, e.g. http://example.com/privacy_icon.png       | `##hb_native_privicon##`  |
+| `privacyLink` | Link to the Privacy Policy of the Buyer, e.g. <http://example.com/privacy>             | `##hb_native_privacy##`   |
+| `privacyIcon` | Icon to display for the privacy link, e.g. <http://example.com/privacy_icon.png>       | `##hb_native_privicon##`  |
 | `cta`         | *Call to Action* text, e.g., "Click here for more information".                      | `##hb_native_cta##`       |
 | `rating`      | Rating information, e.g., "4" out of 5.                                              | `##hb_native_rating##`    |
 | `downloads`   | The total downloads of the advertised application/product                            | `##hb_native_downloads##` |


### PR DESCRIPTION
## Summary
- disable MD041 at the start of the native assets snippet
- wrap example URLs in angle brackets

## Testing
- `markdownlint --config .markdownlint.json _includes/dev-docs/native-assets.md`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_68419e94b358832ba3bbd3a0bf553695