### PR TITLE
Document unlisted configuration parameters

### DIFF
--- a/dev-docs/modules/prebidServer.md
+++ b/dev-docs/modules/prebidServer.md
@@ -97,6 +97,8 @@ There are many configuration options for s2sConfig:
 | `adapterOptions` | Optional | Object | Arguments will be added to resulting OpenRTB payload to Prebid Server in every impression object at request.imp[].ext.BIDDER. See the example above. |
 | `extPrebid` | Optional | Object | Arguments will be added to resulting OpenRTB payload to Prebid Server in request.ext.prebid. See the examples below. |
 | `customHeaders` | Optional | Object | These custom headers will be included in the XHR call to the bidder's endpoint. This will allow you to send data specific to your use case. The format consists of an object where the keys represent the header names and the values correspond to the respective header values. Here is an example how a customHeader object might look like - `{"Header1": "Value1", "Header2": "Value2"}`|
+| `endpointCompression` | Optional | Boolean | Enable gzip compression of outgoing requests when supported. | `true` |
+| `filterBidderlessCalls` | Optional | Boolean | When `true`, ad units that have no bidders defined are excluded from Prebid Server requests. Defaults to `false`. | `true` |
 
 If `endpoint` and `syncEndpoint` are objects, these are the supported properties:
 

--- a/dev-docs/modules/userId.md
+++ b/dev-docs/modules/userId.md
@@ -75,6 +75,9 @@ The PPID in GAM (which is unrelated to the PPID UserId Submodule) has strict rul
 | Param under userSync | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
 | ppid | Optional | String | Must be a source from the [pbjs.getUserIdsAsEids()](#getUserIdsAsEids) array | `"pubcid.org"` |
+| autoRefresh | Optional | Boolean | Refresh IDs automatically when their configuration changes. Defaults to `false`. | `true` |
+| retainConfig | Optional | Boolean | When set to `false`, previously configured IDs are removed if they are not present in updated configuration. Defaults to `true`. | `false` |
+| enforceStorageType | Optional | Boolean | Restrict submodules to storing IDs only in the location defined by `storage.type`. | `true` |
 
 The table below has the options that are common across ID systems. See the sections below for specific configuration needed by each system and examples.
 


### PR DESCRIPTION
## Summary
- document `autoRefresh`, `retainConfig`, and `enforceStorageType` options in User ID module docs
- document `endpointCompression` and `filterBidderlessCalls` in the Prebid Server adapter docs

## Testing
- `markdownlint --config .markdownlint.json dev-docs/modules/userId.md dev-docs/modules/prebidServer.md`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_6865aad3d8ec832bb0c4eee7568d7dca