### PR TITLE
Fix pb10 docs links

### DIFF
--- a/dev-docs/pb10-notes.md
+++ b/dev-docs/pb10-notes.md
@@ -109,5 +109,5 @@ The following modules have been removed from Prebid.js as part of the 10.0 relea
 
 ## Further Reading
 
-* [Publisher API Reference](/dev-docs/publisher-api-reference.html)
-* [First Party Data](/features/firstPartyData.html)
+* [Publisher API Reference](https://docs.prebid.org/dev-docs/publisher-api-reference.html)
+* [First Party Data](https://docs.prebid.org/features/firstPartyData.html)


### PR DESCRIPTION
## Summary
- use docs.prebid.org links for pb10 release notes

## Testing
- `npx markdownlint --config .markdownlint.json dev-docs/pb10-notes.md`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_6866756e86a4832b8273eebdea60efa6