### PR TITLE
Fix docs.prebid.org links

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -49,7 +49,7 @@ Being a reviewer means you're in weekly rotation where you keep an eye on pull r
     5. As for the `media_types` metadata, if they don't support display, then the need to define "no-display". This is because the default metadata table in pbs-bidders.md assumes everyone supports display.
     6. If they claim `tcfeu_support: true`, they must also supply a `gvl_id`. You should check on the [TCF vendor list](https://vendor-list.consensu.org/v3/vendor-list.json) that the GVL ID supplied makes sense. If it's an alias they may define the GVL ID like this: `gvl_id: 14 (adkernel)`
     7. Don't let them claim both pbjs and pbs if they don't have both a Prebid.js and Prebid Server adapter. It's ok to have either a PBS-Go or PBS-Java adapter.
-    8. They cannot claim `fpd_supported` unless the body of their documentation has a section describing how exactly they support First Party Data. You can reject this with a note like "Sorry - you can't claim FPD support unless the document has a description of what kind of First Party data. See the [http://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter](http://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter). We recommend looking at how other adapters have done this. e.g. you can declare that you support site first party data, user first party data, impression-level data, seller-define audience, etc."
+    8. They cannot claim `fpd_supported` unless the body of their documentation has a section describing how exactly they support First Party Data. You can reject this with a note like "Sorry - you can't claim FPD support unless the document has a description of what kind of First Party data. See the [https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter). We recommend looking at how other adapters have done this. e.g. you can declare that you support site first party data, user first party data, impression-level data, seller-define audience, etc."
     9. If they claim to be a `prebid_member`, you can check that on the [prebid.org membership page](https://prebid.org/member-directory/)
 
 ## Core Technologies
@@ -98,7 +98,7 @@ For the Prebid.org site the following directories are used:
 **_data**  
 Jekyll was originally designed specifically for creation of blogging websites and not for dynamic, data-driven sites. However, by including the _data directory we can mimic a database structure to create a more robust site. Files in this directory can be saved in either _json_, _yml_ or _csv_ format. For Prebid.org they have been saved in _yml_.
 
-Learn more about YML [here](https://yaml.org/start.html)
+Learn more about YML in the [YAML Getting Started guide](https://yaml.org/start.html)
 
 There are several YML files in the Prebid _data directory
 

--- a/tools/professor-prebid.md
+++ b/tools/professor-prebid.md
@@ -138,7 +138,7 @@ The UI of the User Sync Network Inspector:
 
 The Request Chain
 
-Data for each resource on a request chain is taken from that resources HAR entry (For more info on HAR entries, see: [http://www.softwareishard.com/blog/har-12-spec](http://www.softwareishard.com/blog/har-12-spec))
+Data for each resource on a request chain is taken from that resources HAR entry (For more info on HAR entries, see: [https://www.softwareishard.com/blog/har-12-spec](https://www.softwareishard.com/blog/har-12-spec))
 
 If a user sync root URL resource is loaded on a webpage, the final resulting request chain object will look like the following (the “redirectsTo” and “initiated” fields can contain zero to many nested resources as values):
 ![Request Chain Example](/assets/images/tools/professor-prebid-12.png)


### PR DESCRIPTION
## Summary
- update docs.prebid.org link to https
- fix markdown linter issue with descriptive link text
- switch HAR spec reference to https

## Testing
- `npx markdownlint --config .markdownlint.json guide.md tools/professor-prebid.md`
- `bundle exec jekyll build` *(fails: rbenv version `2.7.6` is not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686678e7be00832b8a64a44c4146025b